### PR TITLE
Add auth token + credential login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ client.create_connection()
 
 ```
 
+### Authentication
+Guest mode (default):
+
+```python
+from pytradingview import TVclient
+client = TVclient()  # uses TradingView unauthorized_user_token
+```
+
+Auth token mode:
+
+```python
+from pytradingview import TVclient
+client = TVclient(auth_token="YOUR_TRADINGVIEW_AUTH_TOKEN")
+```
+
+Username/password mode (fetches token via TradingView signin endpoint):
+
+```python
+from pytradingview import TVclient
+client = TVclient(username="you@example.com", password="your-password")
+```
+
 #### Command line (CLI)
 ```bash
 python -m pytradingview -d -s '2025-04-24 00:00' -e '2025-04-25 00:00' -p 'FX:EURUSD' 
@@ -63,6 +85,9 @@ python -m pytradingview -d -s '2025-04-24 00:00' -e 'now' -p 'FX:EURUSD'
 ```
 ```bash
 python -m pytradingview --search EURUSD --max 50
+```
+```bash
+python -m pytradingview -d -p 'CME_MINI:ES1!' -t '1' -s '-1d' -e 'now' --username 'you@example.com' --password 'your-password'
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ python -m pytradingview --search EURUSD --max 50
 ```bash
 python -m pytradingview -d -p 'CME_MINI:ES1!' -t '1' -s '-1d' -e 'now' --username 'you@example.com' --password 'your-password'
 ```
+```bash
+export PYTRADINGVIEW_AUTH_TOKEN='YOUR_TRADINGVIEW_AUTH_TOKEN'
+python -m pytradingview -d -p 'CME_MINI:ES1!' -t '1' --start=-2h --end=now -o /tmp/es_1m.csv
+```
 
 ## Contributing
 

--- a/examples/minute_candles_console.py
+++ b/examples/minute_candles_console.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Stream 1-minute candles from TradingView and print them to console.
+"""
+
+import argparse
+import os
+import threading
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import certifi
+
+from pytradingview import TVclient
+from pytradingview.chart import ChartSession
+
+AUTH_TOKEN_ENV_VARS = ("PYTRADINGVIEW_AUTH_TOKEN", "TV_AUTH_TOKEN")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Stream and print 1-minute candles from TradingView websocket."
+    )
+    parser.add_argument(
+        "--symbols",
+        default="CME_MINI:ES1!",
+        help="Comma-separated TradingView symbols",
+    )
+    parser.add_argument("--currency", default="USD", help="Currency code")
+    parser.add_argument(
+        "--auth-token",
+        default=None,
+        help="TradingView auth token (env fallback: PYTRADINGVIEW_AUTH_TOKEN or TV_AUTH_TOKEN)",
+    )
+    parser.add_argument(
+        "--timezone",
+        default="America/New_York",
+        help="Display timezone, e.g. America/New_York or UTC",
+    )
+    parser.add_argument(
+        "--max-closed-bars",
+        type=int,
+        default=0,
+        help="Stop after N closed bars (0 = run until Ctrl+C).",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=0,
+        help="Stop after N seconds (0 = no timeout).",
+    )
+    parser.add_argument(
+        "--print-forming",
+        action="store_true",
+        help="Also print updates for the currently forming minute bar.",
+    )
+    return parser.parse_args()
+
+
+def resolve_auth_token(cli_token):
+    for env_var in AUTH_TOKEN_ENV_VARS:
+        token = os.getenv(env_var)
+        if token:
+            return token
+    return cli_token
+
+
+def to_display_ts(epoch_seconds, tz_name):
+    tz = ZoneInfo(tz_name)
+    dt_utc = datetime.fromtimestamp(int(float(epoch_seconds)), tz=timezone.utc)
+    dt_local = dt_utc.astimezone(tz)
+    return dt_local.strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def format_candle(candle, tz_name):
+    return (
+        f"time={to_display_ts(candle['time'], tz_name)} "
+        f"o={candle['open']} h={candle['high']} "
+        f"l={candle['low']} c={candle['close']} v={candle['volume']}"
+    )
+
+
+def main():
+    args = parse_args()
+    auth_token = resolve_auth_token(args.auth_token)
+
+    if not os.getenv("SSL_CERT_FILE"):
+        os.environ["SSL_CERT_FILE"] = certifi.where()
+
+    symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    if not symbols:
+        raise SystemExit("No symbols provided")
+
+    client = TVclient(auth_token=auth_token)
+    states = {
+        symbol: {"last_candle": None, "closed_count": 0, "done": False}
+        for symbol in symbols
+    }
+
+    def stop(reason):
+        print(f"[stop] {reason}")
+        try:
+            client.end(lambda: None)
+        except Exception:
+            pass
+
+    def on_connected(_):
+        print(f"[connected] symbols={','.join(symbols)} timeframe=1")
+
+    def on_error(err):
+        print(f"[error] {err}")
+
+    def make_on_symbol_loaded(symbol, chart):
+        def on_symbol_loaded(_):
+            desc = chart.get_infos.get("description", "")
+            print(f"[symbol_loaded] symbol={symbol} description={desc}")
+        return on_symbol_loaded
+
+    def maybe_stop_after_max():
+        if args.max_closed_bars <= 0:
+            return
+        all_done = all(states[symbol]["done"] for symbol in symbols)
+        if all_done:
+            stop(f"max closed bars reached for all symbols ({args.max_closed_bars})")
+
+    def make_on_update(symbol, chart):
+        def on_update(_):
+            state = states[symbol]
+            candle = chart.get_periods
+            if not candle:
+                return
+
+            if state["last_candle"] is None:
+                state["last_candle"] = dict(candle)
+                print(f"[forming] symbol={symbol} {format_candle(candle, args.timezone)}")
+                return
+
+            prev = state["last_candle"]
+            prev_ts = int(float(prev["time"]))
+            cur_ts = int(float(candle["time"]))
+
+            if cur_ts != prev_ts:
+                print(f"[closed]  symbol={symbol} {format_candle(prev, args.timezone)}")
+                state["closed_count"] += 1
+                if (
+                    args.max_closed_bars > 0
+                    and state["closed_count"] >= args.max_closed_bars
+                    and not state["done"]
+                ):
+                    state["done"] = True
+                    maybe_stop_after_max()
+
+            if args.print_forming:
+                print(f"[forming] symbol={symbol} {format_candle(candle, args.timezone)}")
+
+            state["last_candle"] = dict(candle)
+
+        return on_update
+
+    client.on_connected(on_connected)
+    client.on_error(on_error)
+
+    charts = []
+    for idx, symbol in enumerate(symbols):
+        chart = client.chart if idx == 0 else ChartSession(client.get_client_brigde)
+        charts.append(chart)
+        chart.on_symbol_loaded(make_on_symbol_loaded(symbol, chart))
+        chart.on_update(make_on_update(symbol, chart))
+        chart.set_up_chart()
+        chart.set_market(
+            symbol,
+            {
+                "timeframe": "1",
+                "currency": args.currency,
+            },
+        )
+
+    if args.timeout_seconds > 0:
+        timer = threading.Timer(args.timeout_seconds, lambda: stop("timeout reached"))
+        timer.daemon = True
+        timer.start()
+
+    client.create_connection()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quote_prices_console.py
+++ b/examples/quote_prices_console.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Stream quote (last-price) updates from TradingView and print to console.
+"""
+
+import argparse
+import os
+import threading
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import certifi
+
+from pytradingview import TVclient
+
+AUTH_TOKEN_ENV_VARS = ("PYTRADINGVIEW_AUTH_TOKEN", "TV_AUTH_TOKEN")
+DEFAULT_SYMBOLS = "CME_MINI:ES1!,CME_MINI:NQ1!,COMEX:GC1!,NYMEX:CL1!,COMEX:SI1!,CBOT_MINI:YM1!,CME_MINI:RTY1!"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Stream and print quote updates (lp/lp_time) from TradingView websocket."
+    )
+    parser.add_argument(
+        "--symbols",
+        default=DEFAULT_SYMBOLS,
+        help="Comma-separated TradingView symbols",
+    )
+    parser.add_argument(
+        "--auth-token",
+        default=None,
+        help="TradingView auth token (env fallback: PYTRADINGVIEW_AUTH_TOKEN or TV_AUTH_TOKEN)",
+    )
+    parser.add_argument(
+        "--timezone",
+        default="America/New_York",
+        help="Display timezone, e.g. America/New_York or UTC",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=0,
+        help="Stop after N seconds (0 = no timeout).",
+    )
+    return parser.parse_args()
+
+
+def resolve_auth_token(cli_token):
+    for env_var in AUTH_TOKEN_ENV_VARS:
+        token = os.getenv(env_var)
+        if token:
+            return token
+    return cli_token
+
+
+def format_epoch(epoch_seconds, tz_name):
+    if epoch_seconds is None:
+        return "n/a"
+    tz = ZoneInfo(tz_name)
+    dt_utc = datetime.fromtimestamp(int(float(epoch_seconds)), tz=timezone.utc)
+    return dt_utc.astimezone(tz).strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def main():
+    args = parse_args()
+    auth_token = resolve_auth_token(args.auth_token)
+    symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    if not symbols:
+        raise SystemExit("No symbols provided")
+
+    if not os.getenv("SSL_CERT_FILE"):
+        os.environ["SSL_CERT_FILE"] = certifi.where()
+
+    client = TVclient(auth_token=auth_token)
+    quote = client.quote
+
+    def stop(reason):
+        print(f"[stop] {reason}")
+        try:
+            client.end(lambda: None)
+        except Exception:
+            pass
+
+    def on_connected(_):
+        print(f"[connected] quote symbols={','.join(symbols)}")
+
+    def on_error(err):
+        print(f"[error] {err}")
+
+    def make_handler(symbol):
+        def handle(packet):
+            if packet["type"] == "quote_completed":
+                print(f"[quote_ready] symbol={symbol}")
+                return
+
+            if packet["type"] != "qsd":
+                return
+
+            payload = packet["data"][1]
+            values = payload.get("v", {})
+            lp = values.get("lp")
+            lp_time = values.get("lp_time")
+            bid = values.get("bid")
+            ask = values.get("ask")
+            volume = values.get("volume")
+
+            recv_ts = datetime.now(timezone.utc).astimezone(ZoneInfo(args.timezone)).strftime(
+                "%Y-%m-%d %H:%M:%S %Z"
+            )
+            print(
+                f"[quote] symbol={symbol} recv={recv_ts} "
+                f"lp={lp} lp_time={format_epoch(lp_time, args.timezone)} "
+                f"bid={bid} ask={ask} volume={volume}"
+            )
+
+        return handle
+
+    client.on_connected(on_connected)
+    client.on_error(on_error)
+
+    quote.set_up_quote({"customFields": ["lp", "lp_time", "bid", "ask", "volume"]})
+    for symbol in symbols:
+        quote.on_symbol(symbol, make_handler(symbol))
+    quote.add_symbols(symbols, fast=True, force_permission=True)
+
+    if args.timeout_seconds > 0:
+        timer = threading.Timer(args.timeout_seconds, lambda: stop("timeout reached"))
+        timer.daemon = True
+        timer.start()
+
+    client.create_connection()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quote_prices_console.py
+++ b/examples/quote_prices_console.py
@@ -42,6 +42,11 @@ def parse_args():
         default=0,
         help="Stop after N seconds (0 = no timeout).",
     )
+    parser.add_argument(
+        "--debug-raw",
+        action="store_true",
+        help="Print raw non-session websocket packets for debugging.",
+    )
     return parser.parse_args()
 
 
@@ -117,6 +122,8 @@ def main():
 
     client.on_connected(on_connected)
     client.on_error(on_error)
+    if args.debug_raw:
+        client.on_data(lambda packet: print(f"[raw] {packet}"))
 
     quote.set_up_quote({"customFields": ["lp", "lp_time", "bid", "ask", "volume"]})
     for symbol in symbols:

--- a/pytradingview/__init__.py
+++ b/pytradingview/__init__.py
@@ -1,0 +1,6 @@
+from .auth import TradingViewAuthError, get_auth_token
+from .client import Client
+
+TVclient = Client
+
+__all__ = ["Client", "TVclient", "TradingViewAuthError", "get_auth_token"]

--- a/pytradingview/__main__.py
+++ b/pytradingview/__main__.py
@@ -1,7 +1,22 @@
 import argparse
+import os
 import sys
 from .utils import parse_datetime
 from .auth import TradingViewAuthError
+
+
+AUTH_TOKEN_ENV_VARS = ("PYTRADINGVIEW_AUTH_TOKEN", "TV_AUTH_TOKEN")
+
+
+def resolve_auth_token(cli_auth_token: str = None) -> str:
+    """
+    Resolve auth token from env vars first, then CLI argument fallback.
+    """
+    for env_var in AUTH_TOKEN_ENV_VARS:
+        token = os.getenv(env_var)
+        if token:
+            return token
+    return cli_auth_token
 
 
 def parse_args():
@@ -15,7 +30,11 @@ def parse_args():
     parser.add_argument('-o', '--output', type=str, help="Output filename.", default="output.csv")
     parser.add_argument('--search', help="Search for symbol using TradingView's symbol search")
     parser.add_argument('--max', type=int, default=50, help="Maximum number of results to return from search (default: 50)")
-    parser.add_argument('--auth-token', type=str, help="TradingView auth token")
+    parser.add_argument(
+        '--auth-token',
+        type=str,
+        help="TradingView auth token (fallback env: PYTRADINGVIEW_AUTH_TOKEN, TV_AUTH_TOKEN)",
+    )
     parser.add_argument('--username', type=str, help="TradingView username/email")
     parser.add_argument('--password', type=str, help="TradingView password")
 
@@ -30,10 +49,11 @@ def main():
     from pytradingview import TVclient
 
     args = parse_args()
+    auth_token = resolve_auth_token(args.auth_token)
 
     try:
         client = TVclient(
-            auth_token=args.auth_token,
+            auth_token=auth_token,
             username=args.username,
             password=args.password,
         )

--- a/pytradingview/__main__.py
+++ b/pytradingview/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 from .utils import parse_datetime
+from .auth import TradingViewAuthError
 
 
 def parse_args():
@@ -30,11 +31,15 @@ def main():
 
     args = parse_args()
 
-    client = TVclient(
-        auth_token=args.auth_token,
-        username=args.username,
-        password=args.password,
-    )
+    try:
+        client = TVclient(
+            auth_token=args.auth_token,
+            username=args.username,
+            password=args.password,
+        )
+    except TradingViewAuthError as exc:
+        print(f"Authentication failed: {exc}")
+        sys.exit(2)
     chart = client.chart
 
     if args.download:

--- a/pytradingview/__main__.py
+++ b/pytradingview/__main__.py
@@ -14,6 +14,9 @@ def parse_args():
     parser.add_argument('-o', '--output', type=str, help="Output filename.", default="output.csv")
     parser.add_argument('--search', help="Search for symbol using TradingView's symbol search")
     parser.add_argument('--max', type=int, default=50, help="Maximum number of results to return from search (default: 50)")
+    parser.add_argument('--auth-token', type=str, help="TradingView auth token")
+    parser.add_argument('--username', type=str, help="TradingView username/email")
+    parser.add_argument('--password', type=str, help="TradingView password")
 
     # Show help if no arguments are provided
     if len(sys.argv) == 1:
@@ -27,7 +30,11 @@ def main():
 
     args = parse_args()
 
-    client = TVclient()
+    client = TVclient(
+        auth_token=args.auth_token,
+        username=args.username,
+        password=args.password,
+    )
     chart = client.chart
 
     if args.download:

--- a/pytradingview/auth.py
+++ b/pytradingview/auth.py
@@ -1,0 +1,77 @@
+"""
+TradingView authentication helpers.
+"""
+
+from typing import Optional
+
+import requests
+
+
+SIGN_IN_URL = "https://www.tradingview.com/accounts/signin/"
+DEFAULT_HEADERS = {
+    "User-Agent": "Mozilla/5.0",
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Referer": "https://www.tradingview.com/",
+    "Origin": "https://www.tradingview.com",
+}
+
+
+class TradingViewAuthError(RuntimeError):
+    """Raised when TradingView login does not return an auth token."""
+
+
+def get_auth_token(
+    username: str,
+    password: str,
+    timeout: int = 20,
+    session: Optional[requests.Session] = None,
+) -> str:
+    """
+    Exchange TradingView username/password credentials for an auth token.
+    """
+    if not username or not password:
+        raise ValueError("username and password are required")
+
+    session_obj = session or requests.Session()
+
+    # Prime CSRF cookies if available; some deployments enforce this.
+    try:
+        session_obj.get(SIGN_IN_URL, headers=DEFAULT_HEADERS, timeout=timeout)
+    except requests.RequestException:
+        # Continue to POST attempt; endpoint behavior can vary by region/edge.
+        pass
+
+    csrf_token = session_obj.cookies.get("csrftoken")
+    payload = {
+        "username": username,
+        "password": password,
+        "remember": "on",
+    }
+
+    headers = dict(DEFAULT_HEADERS)
+    headers["Content-Type"] = "application/x-www-form-urlencoded; charset=UTF-8"
+
+    if csrf_token:
+        payload["csrfmiddlewaretoken"] = csrf_token
+        headers["X-CSRFToken"] = csrf_token
+
+    response = session_obj.post(
+        SIGN_IN_URL,
+        data=payload,
+        headers=headers,
+        timeout=timeout,
+    )
+    response.raise_for_status()
+
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise TradingViewAuthError("sign-in response was not JSON") from exc
+
+    token = data.get("user", {}).get("auth_token")
+    if not token:
+        message = data.get("error") or data.get("message") or "auth token missing"
+        raise TradingViewAuthError(message)
+
+    return token

--- a/pytradingview/auth.py
+++ b/pytradingview/auth.py
@@ -71,7 +71,10 @@ def get_auth_token(
 
     token = data.get("user", {}).get("auth_token")
     if not token:
+        code = data.get("code")
         message = data.get("error") or data.get("message") or "auth token missing"
+        if code:
+            message = f"{message} (code={code})"
         raise TradingViewAuthError(message)
 
     return token

--- a/pytradingview/chart.py
+++ b/pytradingview/chart.py
@@ -352,7 +352,7 @@ class ChartSession:
             if oldest_ts <= start_ts:
                 sorted_data = sorted(self.collected_data, key=lambda x: x['time'], reverse=True)
                 self.save_batch(sorted_data, filename)
-                self.__client['end']() # close the connection
+                self.__client['end'](lambda: None) # close the connection
                 print("✅ Finished downloading requested range.")
                 return
              

--- a/pytradingview/quote.py
+++ b/pytradingview/quote.py
@@ -119,7 +119,8 @@ class QuoteSession:
             self.__client['send']('quote_add_symbols', payload)
 
         if fast:
-            self.__client['send']('quote_fast_symbols', [self.__session_id] + normalized)
+            for symbol in normalized:
+                self.__client['send']('quote_fast_symbols', [self.__session_id, symbol])
 
     def remove_symbol(self, symbol: str):
         """

--- a/pytradingview/quote.py
+++ b/pytradingview/quote.py
@@ -89,6 +89,45 @@ class QuoteSession:
         self.__client = client_bridge
         self.__symbol_listeners = {}
 
+    @property
+    def session_id(self):
+        return self.__session_id
+
+    def on_symbol(self, symbol: str, callback):
+        """
+        Register a callback for quote updates on a specific symbol.
+        """
+        listeners = self.__symbol_listeners.setdefault(symbol, [])
+        listeners.append(callback)
+
+    def add_symbols(self, symbols, fast: bool = True, force_permission: bool = True):
+        """
+        Subscribe one or more symbols to the active quote session.
+        """
+        if isinstance(symbols, str):
+            symbols = [symbols]
+
+        normalized = [s.strip() for s in symbols if s and s.strip()]
+        if not normalized:
+            return
+
+        for symbol in normalized:
+            self.__symbol_listeners.setdefault(symbol, [])
+            payload = [self.__session_id, symbol]
+            if force_permission:
+                payload.append({"flags": ["force_permission"]})
+            self.__client['send']('quote_add_symbols', payload)
+
+        if fast:
+            self.__client['send']('quote_fast_symbols', [self.__session_id] + normalized)
+
+    def remove_symbol(self, symbol: str):
+        """
+        Unsubscribe a symbol from the active quote session.
+        """
+        self.__symbol_listeners.pop(symbol, None)
+        self.__client['send']('quote_remove_symbols', [self.__session_id, symbol])
+
     def on_data_q(self, packet):
         """
         Handles incoming quote data packets and dispatches them to registered symbol listeners.
@@ -117,20 +156,22 @@ class QuoteSession:
         if packet['type'] == 'quote_completed':
 
             symbol = packet['data'][1]
-            if not self.__symbol_listeners[symbol]:
+            listeners = self.__symbol_listeners.get(symbol, [])
+            if not listeners:
                 self.__client['send']('quote_remove_symbols', [self.__session_id, symbol])
                 return
 
-            for h in self.__symbol_listeners[symbol]:
+            for h in listeners:
                 h(packet)
 
         if packet['type'] == 'qsd':
             symbol = packet['data'][1]['n']
-            if not self.__symbol_listeners[symbol]:
+            listeners = self.__symbol_listeners.get(symbol, [])
+            if not listeners:
                 self.__client['send']('quote_remove_symbols', [self.__session_id, symbol])
                 return
 
-            for h in self.__symbol_listeners[symbol]:
+            for h in listeners:
                 h(packet)
 
     def set_up_quote(self, options: dict = None):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import MagicMock
+
+from pytradingview.auth import TradingViewAuthError, get_auth_token
+
+
+def test_get_auth_token_success():
+    session = MagicMock()
+    session.cookies.get.return_value = "csrf-token"
+    response = MagicMock()
+    response.json.return_value = {"user": {"auth_token": "abc123"}}
+    session.post.return_value = response
+
+    token = get_auth_token("user", "pass", session=session)
+
+    assert token == "abc123"
+    session.get.assert_called_once()
+    session.post.assert_called_once()
+
+
+def test_get_auth_token_requires_credentials():
+    with pytest.raises(ValueError):
+        get_auth_token("", "pass")
+
+    with pytest.raises(ValueError):
+        get_auth_token("user", "")
+
+
+def test_get_auth_token_raises_when_missing_token():
+    session = MagicMock()
+    session.cookies.get.return_value = None
+    response = MagicMock()
+    response.json.return_value = {"error": "bad credentials"}
+    session.post.return_value = response
+
+    with pytest.raises(TradingViewAuthError):
+        get_auth_token("user", "pass", session=session)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+import os
+
+from pytradingview.__main__ import resolve_auth_token
+
+
+def test_resolve_auth_token_from_primary_env(monkeypatch):
+    monkeypatch.setenv("PYTRADINGVIEW_AUTH_TOKEN", "env-token")
+    monkeypatch.delenv("TV_AUTH_TOKEN", raising=False)
+
+    assert resolve_auth_token("cli-token") == "env-token"
+
+
+def test_resolve_auth_token_from_secondary_env(monkeypatch):
+    monkeypatch.delenv("PYTRADINGVIEW_AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("TV_AUTH_TOKEN", "tv-env-token")
+
+    assert resolve_auth_token("cli-token") == "tv-env-token"
+
+
+def test_resolve_auth_token_falls_back_to_cli(monkeypatch):
+    monkeypatch.delenv("PYTRADINGVIEW_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("TV_AUTH_TOKEN", raising=False)
+
+    assert resolve_auth_token("cli-token") == "cli-token"
+
+
+def test_resolve_auth_token_none_when_unset(monkeypatch):
+    monkeypatch.delenv("PYTRADINGVIEW_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("TV_AUTH_TOKEN", raising=False)
+
+    assert resolve_auth_token(None) is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,6 +30,21 @@ def test_send(client):
         assert "formatted_packet" in client._Client__send_queue
 
 
+def test_set_auth_token(client):
+    with patch("pytradingview.protocol.format_ws_packet") as mock_format:
+        mock_format.return_value = "auth_packet"
+        client.set_auth_token("token-123")
+        assert client.auth_token == "token-123"
+        assert "auth_packet" in client._Client__send_queue
+
+
+def test_login_sets_token(client):
+    with patch("pytradingview.client.get_auth_token", return_value="auth-token"):
+        token = client.login("user", "pass")
+        assert token == "auth-token"
+        assert client.auth_token == "auth-token"
+
+
 def test_send_queue(client):
     client._Client__is_opened = True
     client._Client__logged = True
@@ -54,6 +69,7 @@ def test_parse_packet_ping(client):
 
 
 def test_parse_packet_error(client):
+    client._Client__is_opened = True
     with patch("pytradingview.protocol.parse_ws_packet") as mock_parse:
         mock_parse.return_value = [{"m": "protocol_error", "p": ["error_details"]}]
         with patch.object(client, "handle_error") as mock_handle_error:
@@ -64,9 +80,34 @@ def test_parse_packet_error(client):
 
 
 def test_on_message(client):
+    client._Client__is_opened = True
     with patch.object(client, "parse_packet") as mock_parse:
-        client.on_message(None, "test_message")
-        mock_parse.assert_called_with("test_message")
+        with patch.object(client, "send_queue") as mock_send_queue:
+            client.on_message(None, "test_message")
+            mock_parse.assert_called_with("test_message")
+            mock_send_queue.assert_called_once()
+
+
+def test_init_with_credentials_requests_token():
+    with patch("pytradingview.client.get_auth_token", return_value="live-token"):
+        client = Client(username="user", password="pass")
+        assert client.auth_token == "live-token"
+
+
+def test_init_with_partial_credentials_fails():
+    with pytest.raises(ValueError):
+        Client(username="user")
+
+    with pytest.raises(ValueError):
+        Client(password="pass")
+
+
+def test_on_message_no_send_queue_when_closed(client):
+    with patch.object(client, "parse_packet") as mock_parse:
+        with patch.object(client, "send_queue") as mock_send_queue:
+            client.on_message(None, "test_message")
+            mock_parse.assert_called_with("test_message")
+            mock_send_queue.assert_not_called()
 
 
 def test_on_close(client):
@@ -92,7 +133,7 @@ def test_create_connection(client):
             on_message=client.on_message,
             on_close=client.on_close,
             on_open=client.on_open,
-            on_error=client.on_error,
+            on_error=client.on_ws_error,
         )
         mock_instance.run_forever.assert_called_once()
 

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from pytradingview.quote import QuoteSession
+
+
+@pytest.fixture
+def client_bridge():
+    return {
+        "sessions": {},
+        "send": MagicMock(),
+        "end": MagicMock(),
+    }
+
+
+@pytest.fixture
+def quote_session(client_bridge):
+    q = QuoteSession(client_bridge)
+    q.set_up_quote({"fields": "price"})
+    return q
+
+
+def test_add_symbols_subscribes_and_fast_tracks(quote_session, client_bridge):
+    quote_session.add_symbols(["CME_MINI:ES1!", "CME_MINI:NQ1!"])
+
+    calls = client_bridge["send"].call_args_list
+    assert any(call.args[0] == "quote_add_symbols" for call in calls)
+    assert any(call.args[0] == "quote_fast_symbols" for call in calls)
+
+
+def test_on_symbol_and_qsd_dispatch(quote_session):
+    received = []
+    quote_session.on_symbol("CME_MINI:ES1!", lambda packet: received.append(packet["type"]))
+
+    quote_session.on_data_q(
+        {
+            "type": "qsd",
+            "data": [
+                quote_session.session_id,
+                {"n": "CME_MINI:ES1!", "v": {"lp": 7000.25}},
+            ],
+        }
+    )
+
+    assert received == ["qsd"]
+
+
+def test_remove_symbol_unsubscribes(quote_session, client_bridge):
+    quote_session.on_symbol("CME_MINI:ES1!", lambda packet: None)
+    quote_session.remove_symbol("CME_MINI:ES1!")
+
+    client_bridge["send"].assert_any_call(
+        "quote_remove_symbols", [quote_session.session_id, "CME_MINI:ES1!"]
+    )


### PR DESCRIPTION
## Summary
- add TradingView credential-to-auth-token helper
- add client auth_token/login APIs and wire token usage into websocket setup
- fix pytradingview public exports so `TVclient` import works
- add CLI auth flags and clearer auth failures
- fix websocket error callback wiring and queue flush on first message
- add auth-focused tests

## Validation
- pytest: 31 passed
- CLI search with futures symbol works
- credential flow surfaces TradingView `rate_limit` error cleanly
